### PR TITLE
[Feat] : entity 연관 관계 매핑

### DIFF
--- a/src/main/java/transfer/banking/server/Application.java
+++ b/src/main/java/transfer/banking/server/Application.java
@@ -2,7 +2,9 @@ package transfer.banking.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class Application {
 

--- a/src/main/java/transfer/banking/server/domain/account/Account.java
+++ b/src/main/java/transfer/banking/server/domain/account/Account.java
@@ -1,0 +1,63 @@
+package transfer.banking.server.domain.account;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.math.BigDecimal;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+import transfer.banking.server.domain.common.BaseTimeEntity;
+
+/**
+ * 계좌 정보를 담는 Entity
+ */
+@Entity
+@NoArgsConstructor
+@Getter
+@GenericGenerator(
+    name = "ACCOUNT_SEQ_GENERATOR",
+    strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator",
+    parameters = {
+        @Parameter(name = "sequence_name", value = "ACCOUNT_SEQ"),
+        @Parameter(name = "initial_value", value = "1"),
+        @Parameter(name = "increment_size", value = "1")
+    }
+)
+public class Account extends BaseTimeEntity {
+
+  /**
+   * 계좌의 고유 ID. Sequence 전략을 사용한다.
+   */
+  @Id
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "ACCOUNT_SEQ_GENERATOR")
+  private Long id;
+
+  /**
+   * 계좌의 고유 번호
+   */
+  private String accountNumber;
+
+  /**
+   * 계좌의 이름
+   */
+  private String accountName;
+
+
+  /**
+   * 계좌의 잔액
+   */
+  private BigDecimal balance;
+
+  @Builder
+  public Account(String accountNumber, String accountName, BigDecimal balance) {
+    this.accountNumber = accountNumber;
+    this.accountName = accountName;
+    this.balance = balance;
+  }
+
+
+}

--- a/src/main/java/transfer/banking/server/domain/account/entity/Account.java
+++ b/src/main/java/transfer/banking/server/domain/account/entity/Account.java
@@ -1,4 +1,4 @@
-package transfer.banking.server.domain.account;
+package transfer.banking.server.domain.account.entity;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/src/main/java/transfer/banking/server/domain/account/entity/Account.java
+++ b/src/main/java/transfer/banking/server/domain/account/entity/Account.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import java.math.BigDecimal;
 import lombok.Builder;
 import lombok.Getter;
@@ -27,6 +28,7 @@ import transfer.banking.server.domain.common.BaseTimeEntity;
         @Parameter(name = "increment_size", value = "1")
     }
 )
+@Table(name = "accounts")
 public class Account extends BaseTimeEntity {
 
   /**

--- a/src/main/java/transfer/banking/server/domain/common/BaseTimeEntity.java
+++ b/src/main/java/transfer/banking/server/domain/common/BaseTimeEntity.java
@@ -1,0 +1,29 @@
+package transfer.banking.server.domain.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * 모든 Entity 의 상위 클래스
+ * Entity 가 생성되어 저장될 때 시간이 자동 저장된다.
+ * Entity 가 수정될 때 시간이 자동 저장된다.
+ */
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+  @CreatedDate
+  @Column(name = "CREATED_AT")
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(name = "MODIFIED_AT")
+  private LocalDateTime modifiedAt;
+}

--- a/src/main/java/transfer/banking/server/domain/friendship/entity/FriendShip.java
+++ b/src/main/java/transfer/banking/server/domain/friendship/entity/FriendShip.java
@@ -1,0 +1,50 @@
+package transfer.banking.server.domain.friendship.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+import transfer.banking.server.domain.common.BaseTimeEntity;
+
+/**
+ * 친구 관계를 담는 Entity
+ */
+
+@Entity
+@NoArgsConstructor
+@Getter
+@GenericGenerator(
+    name = "FRIENDSHIP_SEQ_GENERATOR",
+    strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator",
+    parameters = {
+        @Parameter(name = "sequence_name", value = "FRIENDSHIP_SEQ"),
+        @Parameter(name = "initial_value", value = "1"),
+        @Parameter(name = "increment_size", value = "1")
+    }
+)
+@Table(
+    name = "friendships",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"member_id", "friend_id"})
+    }
+)
+public class FriendShip extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "FRIENDSHIP_SEQ_GENERATOR")
+  private Long id;
+
+  @Column(name = "member_id", nullable = false)
+  private Long memberId;
+
+  @Column(name = "friend_id", nullable = false)
+  private Long friendId;
+
+}

--- a/src/main/java/transfer/banking/server/domain/member/entity/Member.java
+++ b/src/main/java/transfer/banking/server/domain/member/entity/Member.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -26,6 +27,7 @@ import transfer.banking.server.domain.common.BaseTimeEntity;
         @Parameter(name = "increment_size", value = "1")
     }
 )
+@Table(name = "members")
 public class Member extends BaseTimeEntity {
 
   /**

--- a/src/main/java/transfer/banking/server/domain/member/entity/Member.java
+++ b/src/main/java/transfer/banking/server/domain/member/entity/Member.java
@@ -1,0 +1,74 @@
+package transfer.banking.server.domain.member.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+import transfer.banking.server.domain.common.BaseTimeEntity;
+
+/**
+ * 사용자 정보를 담는 Entity
+ */
+@Entity
+@NoArgsConstructor
+@Getter
+@GenericGenerator(
+    name = "MEMBER_SEQ_GENERATOR",
+    strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator",
+    parameters = {
+        @Parameter(name = "sequence_name", value = "MEMBER_SEQ"),
+        @Parameter(name = "initial_value", value = "1"),
+        @Parameter(name = "increment_size", value = "1")
+    }
+)
+public class Member extends BaseTimeEntity {
+
+  /**
+   * 사용자의 고유 ID. Sequence 전략을 사용한다.
+   */
+  @Id
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "MEMBER_SEQ_GENERATOR")
+  private Long id;
+
+  /**
+   * 사용자의 고유 아이디
+   */
+  private String username;
+
+  /**
+   * 사용자의 비밀번호
+   */
+  private String password;
+
+  /**
+   * 사용자의 이메일
+   */
+  private String email;
+
+  /**
+   * 사용자의 이름.
+   */
+  private String name;
+
+  /**
+   * 사용자의 전화번호
+   */
+  private String phoneNumber;
+
+
+  @Builder
+  public Member(String username, String password, String email, String name, String phoneNumber) {
+    this.username = username;
+    this.password = password;
+    this.email = email;
+    this.name = name;
+    this.phoneNumber = phoneNumber;
+  }
+
+
+}

--- a/src/main/java/transfer/banking/server/domain/memberaccount/entity/MemberAccount.java
+++ b/src/main/java/transfer/banking/server/domain/memberaccount/entity/MemberAccount.java
@@ -1,0 +1,63 @@
+package transfer.banking.server.domain.memberaccount.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+import transfer.banking.server.domain.account.entity.Account;
+import transfer.banking.server.domain.common.BaseTimeEntity;
+import transfer.banking.server.domain.member.entity.Member;
+
+/**
+ * 사용자의 계좌 정보를 담는 Entity
+ */
+@Entity
+@NoArgsConstructor
+@Getter
+@GenericGenerator(
+    name = "MEMBER_ACCOUNT_SEQ_GENERATOR",
+    strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator",
+    parameters = {
+        @Parameter(name = "sequence_name", value = "MEMBER_ACCOUNT_SEQ"),
+        @Parameter(name = "initial_value", value = "1"),
+        @Parameter(name = "increment_size", value = "1")
+    }
+)
+public class MemberAccount extends BaseTimeEntity {
+
+  /**
+   * 사용자의 계좌 고유 ID. Sequence 전략을 사용한다.
+   */
+  @Id
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "MEMBER_ACCOUNT_SEQ_GENERATOR")
+  private Long id;
+
+  /**
+   * 사용자의 고유 ID
+   */
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id", nullable = false)
+  private Member member;
+
+  /**
+   * 사용자가 소유하고 있는 계좌의 고유 ID
+   */
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "account_id", nullable = false)
+  private Account account;
+
+  @Builder
+  public MemberAccount(Member member, Account account) {
+    this.member = member;
+    this.account = account;
+  }
+
+}

--- a/src/main/java/transfer/banking/server/domain/memberaccount/entity/MemberAccount.java
+++ b/src/main/java/transfer/banking/server/domain/memberaccount/entity/MemberAccount.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -31,6 +32,7 @@ import transfer.banking.server.domain.member.entity.Member;
         @Parameter(name = "increment_size", value = "1")
     }
 )
+@Table(name = "member_accounts")
 public class MemberAccount extends BaseTimeEntity {
 
   /**

--- a/src/main/java/transfer/banking/server/domain/trasaction/entity/Transaction.java
+++ b/src/main/java/transfer/banking/server/domain/trasaction/entity/Transaction.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import java.math.BigDecimal;
 import lombok.Builder;
 import lombok.Getter;
@@ -32,6 +33,7 @@ import transfer.banking.server.domain.common.BaseTimeEntity;
         @Parameter(name = "increment_size", value = "1")
     }
 )
+@Table(name = "transactions")
 public class Transaction extends BaseTimeEntity {
 
   /**

--- a/src/main/java/transfer/banking/server/domain/trasaction/entity/Transaction.java
+++ b/src/main/java/transfer/banking/server/domain/trasaction/entity/Transaction.java
@@ -1,0 +1,78 @@
+package transfer.banking.server.domain.trasaction.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.math.BigDecimal;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+import transfer.banking.server.domain.account.entity.Account;
+import transfer.banking.server.domain.common.BaseTimeEntity;
+
+/**
+ * 거래 내역 정보를 담는 Entity
+ */
+@Entity
+@NoArgsConstructor
+@Getter
+@GenericGenerator(
+    name = "TRANSACTION_SEQ_GENERATOR",
+    strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator",
+    parameters = {
+        @Parameter(name = "sequence_name", value = "TRANSACTION_SEQ"),
+        @Parameter(name = "initial_value", value = "1"),
+        @Parameter(name = "increment_size", value = "1")
+    }
+)
+public class Transaction extends BaseTimeEntity {
+
+  /**
+   * 거래 내역의 고유 ID. Sequence 전략을 사용한다.
+   */
+  @Id
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "TRANSACTION_SEQ_GENERATOR")
+  private Long id;
+
+  /**
+   * 거래 송신자
+   */
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "sender_id", nullable = false)
+  private Account sender;
+
+  /**
+   * 거래 수신자
+   */
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "receiver_id", nullable = false)
+  private Account receiver;
+
+  /**
+   * 거래 금액
+   */
+  @Column(nullable = false)
+  private BigDecimal amount;
+
+  @Builder
+  public Transaction(Account sender, Account receiver, BigDecimal amount) {
+    this.sender = sender;
+    this.receiver = receiver;
+    this.amount = amount;
+  }
+
+
+
+
+
+
+
+
+}


### PR DESCRIPTION
### ✒️ 관련 이슈번호

- Close #1 

## 🔑 Key Changes

1. Account 의 Balance는 BigDecimal Type으로 할당
2. FriendShip 은 단순히 친구 관계를 나타내기 위함이므로, Member 외래키를 물리적 FK로써 사용하지 않는다.
3. 거래량을 나타내는 필드는 FriendShip Table에서 관리하도록 한다.

