### PR TITLE
[Feat] : bank 와 accountNumber에 복합 index를 걸어서 X-Lock 이 걸리는 범위 최소화 (중요)

### DIFF
--- a/src/main/java/transfer/banking/server/domain/account/adapter/out/persistence/entity/Account.java
+++ b/src/main/java/transfer/banking/server/domain/account/adapter/out/persistence/entity/Account.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import java.math.BigDecimal;
 import lombok.Builder;
@@ -31,7 +32,10 @@ import transfer.banking.server.domain.common.BaseTimeEntity;
         @Parameter(name = "increment_size", value = "1")
     }
 )
-@Table(name = "accounts")
+@Table(
+    name = "accounts",
+    indexes = @Index(name = "idx_bank_account_number", columnList = "bank, account_number", unique = true)
+)
 public class Account extends BaseTimeEntity {
 
   /**
@@ -44,7 +48,7 @@ public class Account extends BaseTimeEntity {
   /**
    * 계좌의 고유 번호
    */
-  @Column(nullable = false, unique = true)
+  @Column(nullable = false, unique = true, name = "account_number")
   private String accountNumber;
 
   /**


### PR DESCRIPTION
### ✒️ 관련 이슈번호

- Close #67 

## 🔑 Key Changes

1. bank 와 accountNumber에 복합 index를 걸어서 X-Lock 이 걸리는 범위 최소화
2. 찾고자 하는 계좌(Account) 에 복합 Index가 존재함으로써, 단 1개의 Record를 찾을 수 있음으로 Record Lock이 걸리게 된다.
3. Gap-Lock 이 걸리지 않아, 불필요한 데이터에 대해 Lock을 걸지 않을 수 있다.
4. Gap-Lock 은 일반적으로 범위 기반 쿼리에서 팬텀 읽기를 방지하는 데 사용된다. 지금처럼 단일 레코드를 효율적으로 찾기 위해 복합 Index를 활용하는 경우에는 Gap-Lock이 필요하지 않는다.

